### PR TITLE
TYP: Remove deprecated Timedelta units

### DIFF
--- a/pandas-stubs/_libs/tslibs/timedeltas.pyi
+++ b/pandas-stubs/_libs/tslibs/timedeltas.pyi
@@ -88,8 +88,6 @@ TimeDeltaUnitChoices: TypeAlias = Literal[
     "nanosecond",
 ]
 
-UnitChoices: TypeAlias = TimeDeltaUnitChoices | Literal["Y", "y", "M"]
-
 class Timedelta(timedelta):
     min: ClassVar[Timedelta]  # pyright: ignore[reportIncompatibleVariableOverride]
     max: ClassVar[Timedelta]  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -478,8 +478,6 @@ def test_timedelta_construction() -> None:
         pd.Timedelta,
     )
 
-
-def test_timedelta_units_restricted() -> None:
     if TYPE_CHECKING_INVALID_USAGE:
         # These should be type errors now as they are not in TimeDeltaUnitChoices
         pd.Timedelta(1, unit="Y")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -479,6 +479,16 @@ def test_timedelta_construction() -> None:
     )
 
 
+def test_timedelta_units_restricted() -> None:
+    if TYPE_CHECKING_INVALID_USAGE:
+        # These should be type errors now as they are not in TimeDeltaUnitChoices
+        pd.Timedelta(1, unit="Y")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+        pd.Timedelta(1, unit="y")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+        pd.Timedelta(1, unit="M")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+
+        pd.to_timedelta(1, unit="Y")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType]
+
+
 def test_timedelta_properties_methods() -> None:
     td = pd.Timedelta("1 day")
     check(assert_type(td.value, int), int)

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -2013,3 +2013,5 @@ def test_guess_datetime_format() -> None:
     check(
         assert_type(guess_datetime_format("2023|September|13"), str | None), type(None)
     )
+
+

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -2013,5 +2013,3 @@ def test_guess_datetime_format() -> None:
     check(
         assert_type(guess_datetime_format("2023|September|13"), str | None), type(None)
     )
-
-


### PR DESCRIPTION
Removes the deprecated and ambiguous unit components ('Y', 'y', 'M') from Timedelta parsing and constructors. Verified with mypy.